### PR TITLE
Fix compiling issue (on Mac)

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,7 @@
 README
+
+  [Update] Revised to compile with OSX (Mac) (The library no longer fails to compile when linked from a project using CMake).
+
   Study the COPYING file for distribution terms and similar.
 
   Visit the cURLpp web site or mirrors for the latest news:

--- a/include/curlpp/Option.inl
+++ b/include/curlpp/Option.inl
@@ -111,7 +111,7 @@ typename Option<OptionType>::ReturnType
 Option<OptionType>::getValue() const
 {
   if(mContainer == NULL)
-    throw UnsetOption(std::string("You are trying to retreive the value of an unset option"));
+    throw UnsetOption("You are trying to retreive the value of an unset option");
 
   return mContainer->getValue();
 }
@@ -145,7 +145,7 @@ OptionTrait<OptionType, option>::updateHandleToMe(internal::CurlHandle * handle)
 {
 	if(this->mContainer == NULL)
 	{
-		throw UnsetOption(std::string("You are trying to set an unset option to a handle"));
+		throw UnsetOption("You are trying to set an unset option to a handle");
 	}	
 
 	internal::OptionSetter<OptionType, option>::setOpt(handle, this->mContainer->getHandleOptionValue());


### PR DESCRIPTION
The library would fail to compile (on Mac OS) because the UnsetOption exception (in file `include/curlpp/Option.inl`) expected a constant string value, but an std::string was passed instead. 

(Although it works fine with `g++` when compiling a single file manually, it used to not compile when linked from a CMake project prior to this change).
