### PR TITLE
Fixing CXXFLAGS regexp in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_PROG_LIBTOOL
 
 LIBTOOL="$LIBTOOL --silent"
 
-CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-O[[0-9]]*//'`"
+CXXFLAGS="`echo $CXXFLAGS | sed -e 's/-O[[0-9s]][[0-9s]]*//'`"
 CURLPP_CXXFLAGS=""
 
 case $host in


### PR DESCRIPTION
Hello,

I have made some tweking to the CXXFLAGS regexp in configure.ac to also catch -Os (otherwise would transform -Os into s and leads to failure in configure when checking for curl/curl.h).
I am cross-compiling for an small platform and my compiler options are including -Os, which makes curlpp fail at configure because of the regexp.

Regards,

Lionel Ains
