### PR TITLE
Support byte array in PostFields

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,6 +23,7 @@ findtool(){
 #--------------------------------------------------------------------------
 # autoconf 2.57 or newer
 #
+echo "Starting autoconf check"
 need_autoconf="2.57"
 ac_version=`${AUTOCONF:-autoconf} --version 2>/dev/null|head -1| sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ac_version"; then
@@ -30,6 +31,7 @@ if test -z "$ac_version"; then
   echo "            You need autoconf version $need_autoconf or newer installed."
   exit 1
 fi
+echo "Pass buildconf check"
 IFS=.; set $ac_version; IFS=' '
 if test "$1" = "2" -a "$2" -lt "57" || test "$1" -lt "2"; then
   echo "buildconf: autoconf version $ac_version found."
@@ -39,12 +41,14 @@ if test "$1" = "2" -a "$2" -lt "57" || test "$1" -lt "2"; then
   echo "            AUTOCONF environment variable."
   exit 1
 fi
+echo "Pass autoconf check"
 
 echo "buildconf: autoconf version $ac_version (ok)"
 
 #--------------------------------------------------------------------------
 # autoheader 2.50 or newer
 #
+echo "Starting autoheader check"
 ah_version=`${AUTOHEADER:-autoheader} --version 2>/dev/null|head -1| sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ah_version"; then
   echo "buildconf: autoheader not found."
@@ -89,6 +93,7 @@ echo "buildconf: automake version $am_version (ok)"
 #--------------------------------------------------------------------------
 # libtool check
 #
+echo "Starting libtool check"
 LIBTOOL_WANTED_MAJOR=1
 LIBTOOL_WANTED_MINOR=4
 LIBTOOL_WANTED_PATCH=2

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,6 @@ findtool(){
 #--------------------------------------------------------------------------
 # autoconf 2.57 or newer
 #
-echo "Starting autoconf check"
 need_autoconf="2.57"
 ac_version=`${AUTOCONF:-autoconf} --version 2>/dev/null|head -1| sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ac_version"; then
@@ -31,7 +30,6 @@ if test -z "$ac_version"; then
   echo "            You need autoconf version $need_autoconf or newer installed."
   exit 1
 fi
-echo "Pass buildconf check"
 IFS=.; set $ac_version; IFS=' '
 if test "$1" = "2" -a "$2" -lt "57" || test "$1" -lt "2"; then
   echo "buildconf: autoconf version $ac_version found."
@@ -41,14 +39,12 @@ if test "$1" = "2" -a "$2" -lt "57" || test "$1" -lt "2"; then
   echo "            AUTOCONF environment variable."
   exit 1
 fi
-echo "Pass autoconf check"
 
 echo "buildconf: autoconf version $ac_version (ok)"
 
 #--------------------------------------------------------------------------
 # autoheader 2.50 or newer
 #
-echo "Starting autoheader check"
 ah_version=`${AUTOHEADER:-autoheader} --version 2>/dev/null|head -1| sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//'`
 if test -z "$ah_version"; then
   echo "buildconf: autoheader not found."
@@ -93,7 +89,6 @@ echo "buildconf: automake version $am_version (ok)"
 #--------------------------------------------------------------------------
 # libtool check
 #
-echo "Starting libtool check"
 LIBTOOL_WANTED_MAJOR=1
 LIBTOOL_WANTED_MINOR=4
 LIBTOOL_WANTED_PATCH=2

--- a/examples/example12.cpp
+++ b/examples/example12.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     
     request.setOpt(new curlpp::options::HttpHeader(header)); 
     
-    request.setOpt(new curlpp::options::PostFields("abcd"));
+    request.setOpt(new curlpp::options::PostFields((const void*)"abcd"));
     request.setOpt(new curlpp::options::PostFieldSize(5));
     
     request.perform(); 

--- a/examples/example16.cpp
+++ b/examples/example16.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
     
     request.setOpt(new curlpp::options::HttpHeader(header)); 
     
-    request.setOpt(new curlpp::options::PostFields("abcd"));
+    request.setOpt(new curlpp::options::PostFields((const void*)"abcd"));
     request.setOpt(new curlpp::options::PostFieldSize(5));
 
     request.setOpt(new curlpp::options::UserPwd("user:password"));

--- a/examples/example21.cpp
+++ b/examples/example21.cpp
@@ -43,18 +43,6 @@
    anonymous namespace to prevent name clash in case other examples using the same global entities
    would be compiled in the same project
 */
-namespace
-{
-
-char *data = NULL;
-
-size_t readData(char *buffer, size_t size, size_t nitems)
-{
-  strncpy(buffer, data, size * nitems);
-  return size * nitems;
-}
-
-} // namespace
 
 int main(int argc, char *argv[])
 {

--- a/include/curlpp/Options.hpp
+++ b/include/curlpp/Options.hpp
@@ -251,7 +251,7 @@ namespace options
 	typedef curlpp::OptionTrait<bool, CURLOPT_PUT> Put;
 	typedef curlpp::OptionTrait<bool, CURLOPT_UPLOAD> Upload;
 	typedef curlpp::OptionTrait<bool, CURLOPT_POST> Post;
-	typedef curlpp::OptionTrait<std::string, CURLOPT_POSTFIELDS> PostFields;
+	typedef curlpp::OptionTrait<const void*, CURLOPT_POSTFIELDS> PostFields;
 	typedef curlpp::OptionTrait<long, CURLOPT_POSTFIELDSIZE> PostFieldSize;
 	typedef curlpp::OptionTrait<curl_off_t, CURLOPT_POSTFIELDSIZE_LARGE> PostFieldSizeLarge;
 	typedef curlpp::OptionTrait<curlpp::Forms, CURLOPT_HTTPPOST> HttpPost;


### PR DESCRIPTION
Right now PostFields only accepts std::string or const char*. In case payload is a byte array, e.g. [0x01 0x01 0x00 0x01], it will drop anything after the first 0x00. This change adds support for byte array in PostFields.